### PR TITLE
preserves focus on move

### DIFF
--- a/src/components/ToolbarButton.vue
+++ b/src/components/ToolbarButton.vue
@@ -4,6 +4,7 @@
       :class="buttonSelector"
       role="button"
       href=""
+      :id="props.id + '-button'"
       :aria-describedby="tooltip"
       :aria-expanded="isExpanded"
       v-on:click.prevent="selectButton"

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,9 +4,17 @@ export const makeCopy = (original) => Object.assign({}, original);
 export const copyToList = (from, to, element) => {
   to.push(makeCopy(element));
 }
+
+const setFocus = (element) => {
+  setTimeout(()=> {
+    document.querySelector(`#${element.id}-button`).focus();
+  })
+}
+
 export const moveToList = (from, to, element) => {
   to.push(element);
   from.splice(from.indexOf(element), 1);
+  setFocus(element);
 }
 
 export const moveInList = (list, element, dir) => {
@@ -16,6 +24,7 @@ export const moveInList = (list, element, dir) => {
   if (condition) {
     list.splice(index + dir, 0, list.splice(index, 1)[0]);
   }
+  setFocus(element);
 }
 
 export const moveUpList = (list, element) => {


### PR DESCRIPTION
I won't be surprised if this needs to be done in a more Vue way. I initially tried to use refs, but could not get refs declared in `ToolbarButton` to be available to the utils functions (refs declared in `App` would show up once I de-arrowed them). If something more Vue-integrated is preferred let me know.