### PR TITLE
[wip?] Accessibility-motivated markup changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,10 +102,10 @@
         border-left: solid 5px transparent;
       }
 
-      .ckeditor5-toolbar-button[aria-expanded="false"] + .ckeditor5-toolbar-tooltip {
+      .ckeditor5-toolbar-tooltip {
         visibility: hidden;
       }
-      .ckeditor5-toolbar-button[aria-expanded="true"] + .ckeditor5-toolbar-tooltip {
+      [data-tip-expanded="true"]  .ckeditor5-toolbar-tooltip {
         visibility: visible;
       }
 

--- a/src/components/ToolbarButton.vue
+++ b/src/components/ToolbarButton.vue
@@ -1,19 +1,13 @@
 <template>
-  <li :class="itemSelector"
+  <li
+      role="option"
+      :class="itemSelector"
       v-on:mouseover="expand"
       v-on:mouseout="hide"
       tabindex="0"
-      @keyup.esc="hide"
-      @keyup.up="move('up')"
-      @keyup.down="move('down')"
-      @keyup.left="move('left')"
-      @keyup.right="move('right')">
-    <span
-      :class="buttonSelector"
-      href=""
       :id="props.id + '-button'"
       :aria-describedby="tooltip"
-      :aria-expanded="isExpanded"
+      :data-tip-expanded="isExpanded"
       v-on:click.prevent="selectButton"
       v-on:focus="expand"
       v-on:blur="hide"
@@ -21,7 +15,10 @@
       @keyup.up="move('up')"
       @keyup.down="move('down')"
       @keyup.left="move('left')"
-      @keyup.right="move('right')"
+      @keyup.right="move('right')">
+    <span
+      :class="buttonSelector"
+      aria-hidden="true"
     >
     </span>
     <span :id="tooltip" class="ckeditor5-toolbar-tooltip" role="tooltip">{{ label }}</span>

--- a/src/components/ToolbarButton.vue
+++ b/src/components/ToolbarButton.vue
@@ -1,8 +1,15 @@
 <template>
-  <li :class="itemSelector" v-on:mouseover="expand" v-on:mouseout="hide">
-    <a
+  <li :class="itemSelector"
+      v-on:mouseover="expand"
+      v-on:mouseout="hide"
+      tabindex="0"
+      @keyup.esc="hide"
+      @keyup.up="move('up')"
+      @keyup.down="move('down')"
+      @keyup.left="move('left')"
+      @keyup.right="move('right')">
+    <span
       :class="buttonSelector"
-      role="button"
       href=""
       :id="props.id + '-button'"
       :aria-describedby="tooltip"
@@ -16,8 +23,7 @@
       @keyup.left="move('left')"
       @keyup.right="move('right')"
     >
-      <span class="visually-hidden" aria-hidden="true">{{ label }}</span>
-    </a>
+    </span>
     <span :id="tooltip" class="ckeditor5-toolbar-tooltip" role="tooltip">{{ label }}</span>
   </li>
 </template>


### PR DESCRIPTION
This originated from https://www.drupal.org/project/ckeditor5/issues/3209517, there are several changes here

- sorting now happens on the list item itself, the previous way was via links with `role="button"`. Although those items _represent_ buttons, they should not be conveyed as buttons to assistive tech as they are not clickable elements that trigger a reposnse when clicked
- `aria-expanded` is no longer used as an attribute, the content that is hidden/shown isn't really _toggleable_, it's shown on hover/focus. The content of the tooltip is in the aria-labelledby span, so the tooltip content is announced on focus already.
- There is no need for the visually-hidden span with the button type as this content is already supplied via aria-labelledby span containing the tooltip content
- This currently has a [wip?] because the list items have `role="option"`, so the containing `<ul>` really should have `role="listbox"`. I submitted a PR to vue.draggable https://github.com/SortableJS/vue.draggable.next/pull/35 to make this possible. However, I think the fallback behavior (describing the list option as a "text element",) is preferable to it being described as a button.

If this lands a bit CSS in Drupal will need to be changed since aria-expanded won't be used (and ideally aria attributes shouldn't be used for CSS anyway)
```
.ckeditor5-toolbar-button[aria-expanded="false"] + .ckeditor5-toolbar-tooltip {
  visibility: hidden;
}
.ckeditor5-toolbar-button[aria-expanded="true"] + .ckeditor5-toolbar-tooltip {
  visibility: visible;
}
```
to
```
.ckeditor5-toolbar-tooltip {
  visibility: hidden;
}
[data-tip-expanded="true"]  .ckeditor5-toolbar-tooltip {
  visibility: visible;
}
```
