### PR TITLE
add conditional behavior for dividers

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -39,10 +39,11 @@
             :name="element.name"
             :label="element.label"
             :actions="{
-              down: () => copyToList(dividers, listSelected, element),
+              down: () => copyToActiveButtons(dividers, listSelected, element),
               focus: () => onFocusDisabled(element),
             }"
             :alert="() => listSelf('dividers', dividers, element)"
+            :divider="true"
           />
         </template>
       </draggable>
@@ -63,9 +64,9 @@
           :name="element.name"
           :label="element.label"
           :actions="{
-            up: () => moveToList(listSelected, listAvailable, element),
-            [sortUp]: () => moveUpList(listSelected, element),
-            [sortDn]: () => moveDnList(listSelected, element),
+            up: () => moveToList(listSelected, listAvailable, element, listDividers.map(item => item.id).includes(element.id)),
+            [sortUp]: () => moveUpActiveButtons(listSelected, element),
+            [sortDn]: () => moveDownActiveButtons(listSelected, element),
             focus: () => onFocusActive(element),
           }"
         />
@@ -82,11 +83,11 @@ import HelpText from './components/HelpText.vue';
 import Parser from './parser';
 import {
   makeCopy,
-  copyToList,
+  copyToActiveButtons,
   moveToList,
-  moveInList,
-  moveUpList,
-  moveDnList,
+  moveWithinActiveButtons,
+  moveUpActiveButtons,
+  moveDownActiveButtons,
 } from './utils';
 
 const props = defineProps({

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,13 @@
 
 export const makeCopy = (original) => Object.assign({}, original);
 
-export const copyToList = (from, to, element) => {
+export const copyToActiveButtons = (from, to, element) => {
   to.push(makeCopy(element));
+  setTimeout(() => {
+    // A divider added to active buttons will be the last item in the list.
+    // Focus that item.
+    document.querySelector('.ckeditor5-toolbar-active__buttons li:last-child a').focus();
+  });
 }
 
 const setFocus = (element) => {
@@ -11,26 +16,40 @@ const setFocus = (element) => {
   })
 }
 
-export const moveToList = (from, to, element) => {
-  to.push(element);
+export const moveToList = (from, to, element, divider = false) => {
+  const elementIndex = from.indexOf(element);
+  if (!divider) {
+    to.push(element);
+    setFocus(element);
+  } else {
+    // If this is a divider, then this is being called to remove it from the
+    // active buttons list. Focus the item to the left of the removed divider.
+    setTimeout(() => {
+      document.querySelector(`.ckeditor5-toolbar-active__buttons li:nth-child(${Math.max(elementIndex, 0)}) a`).focus();
+    });
+
+  }
   from.splice(from.indexOf(element), 1);
-  setFocus(element);
+
 }
 
-export const moveInList = (list, element, dir) => {
+export const moveWithinActiveButtons = (list, element, dir) => {
   const index = list.indexOf(element);
   // If moving up, check it is not the first, else check it is not the last.
   const condition = dir < 0 ? index > 0 : index < list.length - 1;
   if (condition) {
     list.splice(index + dir, 0, list.splice(index, 1)[0]);
+    // After rendering, focus the element that was just moved.
+    setTimeout(() => {
+      document.querySelectorAll(`.ckeditor5-toolbar-active__buttons li`)[index + dir].querySelector('a').focus();
+    });
   }
-  setFocus(element);
 }
 
-export const moveUpList = (list, element) => {
-  moveInList(list, element, -1);
+export const moveUpActiveButtons = (list, element) => {
+  moveWithinActiveButtons(list, element, -1);
 }
 
-export const moveDnList = (list, element) => {
-  moveInList(list, element, 1);
+export const moveDownActiveButtons = (list, element) => {
+  moveWithinActiveButtons(list, element, 1);
 }


### PR DESCRIPTION
Retaining focus with dividers requires some divider-specific logic since there can be multiple instances of them.