### PR TITLE
A11y cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,10 +102,10 @@
         border-left: solid 5px transparent;
       }
 
-      .ckeditor5-toolbar-button[aria-expanded="false"] + .ckeditor5-toolbar-tooltip {
+      .ckeditor5-toolbar-button + .ckeditor5-toolbar-tooltip {
         visibility: hidden;
       }
-      .ckeditor5-toolbar-button[aria-expanded="true"] + .ckeditor5-toolbar-tooltip {
+      .ckeditor5-toolbar-button[data-expanded="true"] + .ckeditor5-toolbar-tooltip {
         visibility: visible;
       }
 
@@ -215,7 +215,7 @@
         "imageUpload":{"label":"Image upload"}
       }
     </div>
-    <textarea name="ckeditor5-toolbar-buttons-selected" id="ckeditor5-toolbar-buttons-selected" cols="30" rows="10">["heading","bold","italic","|","imageUpload", "|"]</textarea>
+    <textarea tabindex="-1" aria-hidden="true" name="ckeditor5-toolbar-buttons-selected" id="ckeditor5-toolbar-buttons-selected" cols="30" rows="10">["heading","bold","italic","|","imageUpload", "|"]</textarea>
     <script>
       // Dummy global Drupal object.
       window.Drupal = {

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,9 +2,10 @@
   <HelpText :items="toolbarHelpText" />
   <div class="ckeditor5-toolbar-disabled">
     <div class="ckeditor5-toolbar-available">
-      <label for="ckeditor5-toolbar-available__buttons">Available buttons</label>
+      <label id="ckeditor5-toolbar-available__buttons-label">Available buttons</label>
       <draggable
         class="ckeditor5-toolbar-tray ckeditor5-toolbar-available__buttons"
+        aria-labelledby="ckeditor5-toolbar-available__buttons-label"
         tag="ul"
         :list="listAvailable"
         group="toolbar"
@@ -25,9 +26,10 @@
       </draggable>
     </div>
     <div class="ckeditor5-toolbar-divider">
-      <label for="ckeditor5-toolbar-divider__buttons">Button divider</label>
+      <label id="ckeditor5-toolbar-divider__buttons-label">Button divider</label>
       <draggable
         class="ckeditor5-toolbar-tray ckeditor5-toolbar-divider__buttons"
+        aria-labelledby="ckeditor5-toolbar-divider__buttons-label"
         tag="ul"
         :list="listDividers"
         :group="{ name: 'toolbar', put: false, pull: 'clone', sort: 'false' }"
@@ -54,6 +56,7 @@
     <label for="ckeditor5-toolbar-active__buttons">Active toolbar</label>
     <draggable
       class="ckeditor5-toolbar-tray ckeditor5-toolbar-active__buttons"
+      id="ckeditor5-toolbar-active__buttons"
       tag="ul"
       :list="listSelected"
       group="toolbar"

--- a/src/App.vue
+++ b/src/App.vue
@@ -53,10 +53,10 @@
     </div>
   </div>
   <div class="ckeditor5-toolbar-active">
-    <label for="ckeditor5-toolbar-active__buttons">Active toolbar</label>
+    <label id="ckeditor5-toolbar-active__buttons-label">Active toolbar</label>
     <draggable
       class="ckeditor5-toolbar-tray ckeditor5-toolbar-active__buttons"
-      id="ckeditor5-toolbar-active__buttons"
+      aria-labelledby="ckeditor5-toolbar-active__buttons-label"
       tag="ul"
       :list="listSelected"
       group="toolbar"

--- a/src/App.vue
+++ b/src/App.vue
@@ -179,6 +179,10 @@ watch(
   },
 );
 
+// @todo add these attributes directly to the sortable list when
+//    https://github.com/SortableJS/vue.draggable.next/pull/35 lands.
+//    onMounted and onUpdated can be removed as well if their only purpose is
+//    calling this function.
 const updateRoles = () => {
   document.querySelectorAll('[data-button-list]').forEach((list) => {
     const buttonListId = list.getAttribute('data-button-list');

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,12 +5,12 @@
       <label id="ckeditor5-toolbar-available__buttons-label">Available buttons</label>
       <draggable
         class="ckeditor5-toolbar-tray ckeditor5-toolbar-available__buttons"
-        aria-labelledby="ckeditor5-toolbar-available__buttons-label"
         tag="ul"
         :list="listAvailable"
         group="toolbar"
         itemKey="id"
         @add="onAddToAvailable"
+        data-button-list="ckeditor5-toolbar-available__buttons"
       >
         <template #item="{ element }">
           <ToolbarButton
@@ -29,12 +29,12 @@
       <label id="ckeditor5-toolbar-divider__buttons-label">Button divider</label>
       <draggable
         class="ckeditor5-toolbar-tray ckeditor5-toolbar-divider__buttons"
-        aria-labelledby="ckeditor5-toolbar-divider__buttons-label"
         tag="ul"
         :list="listDividers"
         :group="{ name: 'toolbar', put: false, pull: 'clone', sort: 'false' }"
         itemKey="id"
         :clone="makeCopy"
+        data-button-list="ckeditor5-toolbar-divider__buttons"
       >
         <template #item="{ element }">
           <ToolbarButton
@@ -56,11 +56,11 @@
     <label id="ckeditor5-toolbar-active__buttons-label">Active toolbar</label>
     <draggable
       class="ckeditor5-toolbar-tray ckeditor5-toolbar-active__buttons"
-      aria-labelledby="ckeditor5-toolbar-active__buttons-label"
       tag="ul"
       :list="listSelected"
       group="toolbar"
       itemKey="id"
+      data-button-list="ckeditor5-toolbar-active__buttons"
     >
       <template #item="{ element }">
         <ToolbarButton
@@ -81,7 +81,7 @@
 </template>
 
 <script setup>
-import { computed, defineProps, shallowReactive, watch } from 'vue';
+import { computed, defineProps, shallowReactive, watch, onUpdated, onMounted } from 'vue';
 import draggable from 'vuedraggable';
 import ToolbarButton from './components/ToolbarButton.vue';
 import HelpText from './components/HelpText.vue';
@@ -170,6 +170,7 @@ const selectedItems = computed(
   () => `[${listSelected.map((item) => `"${item.name}"`).join(',')}]`,
 );
 
+
 // Update textarea
 watch(
   () => selectedItems.value,
@@ -177,4 +178,21 @@ watch(
     parser.setSelected(currSelected);
   },
 );
+
+const updateRoles = () => {
+  document.querySelectorAll('[data-button-list]').forEach((list) => {
+    const buttonListId = list.getAttribute('data-button-list');
+    list.setAttribute('role', 'listbox');
+    list.setAttribute('aria-orientation', 'horizontal');
+    list.setAttribute('aria-labelledby', `${buttonListId}-label`)
+  });
+}
+
+onMounted(() => {
+  updateRoles()
+});
+
+onUpdated(() => {
+  updateRoles()
+});
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -81,7 +81,7 @@
 </template>
 
 <script setup>
-import { computed, defineProps, shallowReactive, watch, onUpdated, onMounted } from 'vue';
+import { computed, defineProps, shallowReactive, watch, onMounted } from 'vue';
 import draggable from 'vuedraggable';
 import ToolbarButton from './components/ToolbarButton.vue';
 import HelpText from './components/HelpText.vue';

--- a/src/App.vue
+++ b/src/App.vue
@@ -195,8 +195,4 @@ const updateRoles = () => {
 onMounted(() => {
   updateRoles()
 });
-
-onUpdated(() => {
-  updateRoles()
-});
 </script>

--- a/src/components/ToolbarButton.vue
+++ b/src/components/ToolbarButton.vue
@@ -4,9 +4,9 @@
       :class="buttonSelector"
       role="button"
       href=""
-      :id="props.id + '-button'"
+      :id="buttonId"
       :aria-describedby="tooltip"
-      :aria-expanded="isExpanded"
+      :data-expanded="isExpanded"
       v-on:click.prevent="selectButton"
       v-on:focus="expand"
       v-on:blur="hide"
@@ -16,9 +16,9 @@
       @keyup.left="move('left')"
       @keyup.right="move('right')"
     >
-      <span class="visually-hidden" aria-hidden="true">{{ label }}</span>
+      <span class="visually-hidden">{{ label }}</span>
     </a>
-    <span :id="tooltip" class="ckeditor5-toolbar-tooltip" role="tooltip">{{ label }}</span>
+    <span :id="tooltip" class="ckeditor5-toolbar-tooltip" aria-hidden="true">{{ label }}</span>
   </li>
 </template>
 
@@ -58,6 +58,7 @@ const move = (dir) => {
 
 const itemSelector = `ckeditor5-toolbar-item ckeditor5-toolbar-item-${props.id}`;
 const buttonSelector = `ckeditor5-toolbar-button ckeditor5-toolbar-button-${props.id}`;
-const tooltip = `ckeditor5-toolbar-tooltip-${props.id}`
+const buttonId = `${props.id}-button-${Math.random().toString(36).substring(7)}`;
+const tooltip = `ckeditor5-toolbar-tooltip-${props.id}-${Math.random().toString(36).substring(7)}`;
 
 </script>

--- a/src/components/ToolbarButton.vue
+++ b/src/components/ToolbarButton.vue
@@ -5,7 +5,6 @@
       role="button"
       href=""
       :id="buttonId"
-      :aria-describedby="tooltip"
       :data-expanded="isExpanded"
       v-on:click.prevent="selectButton"
       v-on:focus="expand"
@@ -18,7 +17,7 @@
     >
       <span class="visually-hidden">{{ label }}</span>
     </a>
-    <span :id="tooltip" class="ckeditor5-toolbar-tooltip" aria-hidden="true">{{ label }}</span>
+    <span class="ckeditor5-toolbar-tooltip" aria-hidden="true">{{ label }}</span>
   </li>
 </template>
 
@@ -59,6 +58,5 @@ const move = (dir) => {
 const itemSelector = `ckeditor5-toolbar-item ckeditor5-toolbar-item-${props.id}`;
 const buttonSelector = `ckeditor5-toolbar-button ckeditor5-toolbar-button-${props.id}`;
 const buttonId = `${props.id}-button-${Math.random().toString(36).substring(7)}`;
-const tooltip = `ckeditor5-toolbar-tooltip-${props.id}-${Math.random().toString(36).substring(7)}`;
 
 </script>


### PR DESCRIPTION
This addresses fairly basic things, several of which  would be flagged in automated checks.
- `ul` elements are not labelable, so the labels for the button lists need to be associated by using aria-labelledby.
- The `ul` elements need to be seen as form elements. The CK4 approach was to give them `role="form:`, which makes them labelable, but semanically confusing due to their being a form within a form. Changed to use `role="listbox"` via regular JS as Sortable filters role and aria attributes and I'm unsure when/if the PR addressing this will land https://github.com/zrpnr/ckeditor5-drupal-admin/pull/new/a11y-cleanup
- Button Ids need to be unique, added a random string at the end of ids to ensure this.
- The `span` within the button was invisible to eyes and screenreaders due to being visually-hidden and aria-hidden. This also triggered concerns on Axe dev tools as it expected `<a>` tags to have content. The aria hidden was removed so it's visible to screenreaders. 
- The prior step eliminated the need to associate the button with the tooltip. The tooltip is now aria-hidden as it duplicates the contents of the button. It is only needed for sighted users, and the aria-expanded is not needed either. The part that "expands" is always available to screenreaders.
- A few changes in index.html. The CSS expecting aria-hidden will need to be changed in the CKEditor 5 Drupal module when these changes are imported. The textarea change was to make testing with automated tools a little easier.
