### PR TITLE
aria listbox pattern full implementation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -68,7 +68,7 @@
           :name="element.name"
           :label="element.label"
           :actions="{
-            up: () => moveToList(listSelected, listAvailable, element, listDividers.map(item => item.id).includes(element.id)),
+            up: () => moveToList(listSelected, listAvailable, element, listDividers.map(item => item.id).includes(element.id), false),
             [sortUp]: () => moveUpActiveButtons(listSelected, element),
             [sortDn]: () => moveDownActiveButtons(listSelected, element),
             focus: () => onFocusActive(element),

--- a/src/components/ToolbarButton.vue
+++ b/src/components/ToolbarButton.vue
@@ -1,12 +1,10 @@
 <template>
-  <li :class="itemSelector" v-on:mouseover="expand" v-on:mouseout="hide">
-    <a
-      :class="buttonSelector"
-      role="button"
-      href=""
-      :id="buttonId"
-      :data-expanded="isExpanded"
-      v-on:click.prevent="selectButton"
+  <li
+      :class="itemSelector"
+      v-on:mouseover="expand"
+      v-on:mouseout="hide"
+      role="option"
+      tabindex="0"
       v-on:focus="expand"
       v-on:blur="hide"
       @keyup.esc="hide"
@@ -14,9 +12,13 @@
       @keyup.down="move('down')"
       @keyup.left="move('left')"
       @keyup.right="move('right')"
+  >
+    <span
+      :class="buttonSelector"
+      :data-expanded="isExpanded"
     >
       <span class="visually-hidden">{{ label }}</span>
-    </a>
+    </span>
     <span class="ckeditor5-toolbar-tooltip" aria-hidden="true">{{ label }}</span>
   </li>
 </template>
@@ -57,6 +59,5 @@ const move = (dir) => {
 
 const itemSelector = `ckeditor5-toolbar-item ckeditor5-toolbar-item-${props.id}`;
 const buttonSelector = `ckeditor5-toolbar-button ckeditor5-toolbar-button-${props.id}`;
-const buttonId = `${props.id}-button-${Math.random().toString(36).substring(7)}`;
 
 </script>

--- a/src/components/ToolbarButton.vue
+++ b/src/components/ToolbarButton.vue
@@ -12,6 +12,7 @@
       @keyup.down="move('down')"
       @keyup.left="move('left')"
       @keyup.right="move('right')"
+      v-on:click="selectButton"
   >
     <span
       :class="buttonSelector"

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,6 +14,8 @@ export const moveToList = (from, to, element, divider = false, toActive = true )
   const elementIndex = from.indexOf(element);
   if (!divider) {
     to.push(element);
+    // The selector for the list being moved to is determined by seeing if the
+    // element is being moved to the active or available button list.
     const selector = toActive ? '.ckeditor5-toolbar-active__buttons' : '.ckeditor5-toolbar-available__buttons';
     setTimeout(() => {
       document.querySelector(`${selector} li:last-child`).focus();

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,31 +6,26 @@ export const copyToActiveButtons = (from, to, element) => {
   setTimeout(() => {
     // A divider added to active buttons will be the last item in the list.
     // Focus that item.
-    document.querySelector('.ckeditor5-toolbar-active__buttons li:last-child a').focus();
+    document.querySelector('.ckeditor5-toolbar-active__buttons li:last-child').focus();
   });
 }
 
-const setFocus = (element) => {
-  setTimeout(()=> {
-    document.querySelector(`#${element.id}-button`).focus();
-  })
-}
-
-export const moveToList = (from, to, element, divider = false) => {
+export const moveToList = (from, to, element, divider = false, toActive = true ) => {
   const elementIndex = from.indexOf(element);
   if (!divider) {
     to.push(element);
-    setFocus(element);
+    const selector = toActive ? '.ckeditor5-toolbar-active__buttons' : '.ckeditor5-toolbar-available__buttons';
+    setTimeout(() => {
+      document.querySelector(`${selector} li:last-child`).focus();
+    });
   } else {
     // If this is a divider, then this is being called to remove it from the
     // active buttons list. Focus the item to the left of the removed divider.
     setTimeout(() => {
-      document.querySelector(`.ckeditor5-toolbar-active__buttons li:nth-child(${Math.max(elementIndex, 0)}) a`).focus();
+      document.querySelector(`.ckeditor5-toolbar-active__buttons li:nth-child(${Math.max(elementIndex, 0)})`).focus();
     });
-
   }
   from.splice(from.indexOf(element), 1);
-
 }
 
 export const moveWithinActiveButtons = (list, element, dir) => {
@@ -41,7 +36,7 @@ export const moveWithinActiveButtons = (list, element, dir) => {
     list.splice(index + dir, 0, list.splice(index, 1)[0]);
     // After rendering, focus the element that was just moved.
     setTimeout(() => {
-      document.querySelectorAll(`.ckeditor5-toolbar-active__buttons li`)[index + dir].querySelector('a').focus();
+      document.querySelectorAll(`.ckeditor5-toolbar-active__buttons li`)[index + dir].focus();
     });
   }
 }


### PR DESCRIPTION
Upon further review the work in https://github.com/zrpnr/ckeditor5-drupal-admin/pull/8 needed to be elaborated upon.

The listbox role is what allows the button lists to be identified as active elements within the form. A  Listbox requires the immediate children to be focusable, and those must have no focusable children of their own. Fortunately it was relatively easy to change the `<a>` "buttons" to `<span>` and move the keyboard and focus handlers to the `<li>`. It's a big refactor so there may be a missing use case in there... 