### PR TITLE
Screenreader improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,6 +216,9 @@
       }
     </div>
     <textarea tabindex="-1" aria-hidden="true" name="ckeditor5-toolbar-buttons-selected" id="ckeditor5-toolbar-buttons-selected" cols="30" rows="10">["heading","bold","italic","|","imageUpload", "|"]</textarea>
+    <div class="visually-hidden" id="available-button-description">Press the down arrow key to add to the toolbar.</div>
+    <div class="visually-hidden" id="active-button-description">Move this button in the toolbar by pressing the left or right arrow keys. Press the up arrow key to remove from the toolbar.</div>
+
     <script>
       // Dummy global Drupal object.
       window.Drupal = {
@@ -224,24 +227,15 @@
         }
       }
 
-      const add = "Press the down arrow key to add to the toolbar."
-      const remove = "Press the up arrow key to remove from the toolbar.";
-      const sort = "Move this button in the toolbar by pressing the left or right arrow keys.";
-      const sortFirst = "Move this button down the toolbar by pressing the right arrow key.";
-      const sortLast = "Move this button up the toolbar by pressing the left arrow key.";
-
       const announcements = {
-        onFocusDisabled(name) {
-          Drupal.announce(`Available button ${name}. ${add}`);
+        onButtonMovedActive(name) {
+          Drupal.announce(`Button ${name} has been moved to the active toolbar.`);
         },
-        onFocusActive(name) {
-          Drupal.announce(`Active button ${name}. ${sort} ${remove}`);
+        onButtonCopiedActive(name) {
+          Drupal.announce(`Button ${name} has been copied to the active toolbar.`);
         },
-        onFocusActiveFirst(name) {
-          Drupal.announce(`Active button ${name} is first in the toolbar. ${sortFirst} ${remove}`);
-        },
-        onFocusActiveLast(name) {
-          Drupal.announce(`Active button ${name} is last in the toolbar. ${sortLast} ${remove}`);
+        onButtonMovedInactive(name) {
+          Drupal.announce(`Button ${name} has been removed from the active toolbar.`);
         },
       };
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,8 +19,8 @@
             :label="element.label"
             :actions="{
               down: () => moveToList(listAvailable, listSelected, element),
-              focus: () => onFocusDisabled(element),
             }"
+            listType="available"
           />
         </template>
       </draggable>
@@ -43,10 +43,10 @@
             :label="element.label"
             :actions="{
               down: () => copyToActiveButtons(dividers, listSelected, element),
-              focus: () => onFocusDisabled(element),
             }"
             :alert="() => listSelf('dividers', dividers, element)"
             data-divider="true"
+            listType="available"
           />
         </template>
       </draggable>
@@ -71,9 +71,9 @@
             up: () => moveToList(listSelected, listAvailable, element, listDividers.map(item => item.id).includes(element.id), false),
             [sortUp]: () => moveUpActiveButtons(listSelected, element),
             [sortDn]: () => moveDownActiveButtons(listSelected, element),
-            focus: () => onFocusActive(element),
           }"
           :data-divider="listDividers.map(item => item.id).includes(element.id)"
+          listType="active"
         />
       </template>
     </draggable>
@@ -111,30 +111,6 @@ const parser = new Parser({
   availableId: 'ckeditor5-toolbar-buttons-available',
   selectedId: 'ckeditor5-toolbar-buttons-selected',
 });
-
-const onFocusDisabled = (element) => {
-  if (announcements && announcements.onFocusDisabled) {
-    announcements.onFocusDisabled(element.label);
-  }
-};
-
-const onFocusActive = (element) => {
-  if (announcements) {
-    const index = listSelected.indexOf(element);
-    const position = index + 1;
-    const length = listSelected.length;
-
-    if (index === 0 && announcements.onFocusActiveFirst) {
-      announcements.onFocusActiveFirst(element.label);
-    } else if (position === length && announcements.onFocusActiveLast) {
-      announcements.onFocusActiveLast(element.label);
-    } else {
-      if (announcements.onFocusActive) {
-        announcements.onFocusActive(element.label, position, length);
-      }
-    }
-  }
-};
 
 const onAddToAvailable = (event) => {
   // If the moved item is a divider, it should not be added to the available

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,7 +18,7 @@
             :name="element.name"
             :label="element.label"
             :actions="{
-              down: () => moveToList(listAvailable, listSelected, element),
+              down: () => moveToList(listAvailable, listSelected, element, announcements.onButtonMovedActive),
             }"
             listType="available"
           />
@@ -42,7 +42,7 @@
             :name="element.name"
             :label="element.label"
             :actions="{
-              down: () => copyToActiveButtons(dividers, listSelected, element),
+              down: () => copyToActiveButtons(dividers, listSelected, element, announcements.onButtonCopiedActive),
             }"
             :alert="() => listSelf('dividers', dividers, element)"
             data-divider="true"
@@ -68,7 +68,7 @@
           :name="element.name"
           :label="element.label"
           :actions="{
-            up: () => moveToList(listSelected, listAvailable, element, listDividers.map(item => item.id).includes(element.id), false),
+            up: () => moveToList(listSelected, listAvailable, element, announcements.onButtonMovedInactive, listDividers.map(item => item.id).includes(element.id), false),
             [sortUp]: () => moveUpActiveButtons(listSelected, element),
             [sortDn]: () => moveDownActiveButtons(listSelected, element),
           }"

--- a/src/components/ToolbarButton.vue
+++ b/src/components/ToolbarButton.vue
@@ -13,12 +13,13 @@
       @keyup.left="move('left')"
       @keyup.right="move('right')"
       v-on:click="selectButton"
+      :aria-describedby="props.listType + '-button-description'"
   >
     <span
       :class="buttonSelector"
       :data-expanded="isExpanded"
     >
-      <span class="visually-hidden">{{ label }}</span>
+      <span class="visually-hidden">{{props.listType}} button {{ label }}</span>
     </span>
     <span class="ckeditor5-toolbar-tooltip" aria-hidden="true">{{ label }}</span>
   </li>
@@ -32,6 +33,7 @@ const props = defineProps({
   label: String,
   id: String,
   actions: Object,
+  listType: String,
 });
 
 const isExpanded = ref(false);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,21 +1,19 @@
-
 export const makeCopy = (original) => Object.assign({}, original);
 
-export const copyToActiveButtons = (from, to, element) => {
+export const copyToActiveButtons = (from, to, element, announceChange) => {
   to.push(makeCopy(element));
   setTimeout(() => {
     // A divider added to active buttons will be the last item in the list.
     // Focus that item.
     document.querySelector('.ckeditor5-toolbar-active__buttons li:last-child').focus();
-    if (announcements && announcements.onButtonCopiedActive) {
-      announcements.onButtonCopiedActive(element.label);
+    if (announceChange) {
+      announceChange(element.label);
     }
   });
 }
 
-export const moveToList = (from, to, element, divider = false, toActive = true ) => {
+export const moveToList = (from, to, element, announceChange, divider = false, toActive = true) => {
   const elementIndex = from.indexOf(element);
-  const announceFunction = toActive ? 'onButtonMovedActive' : 'onButtonMovedInactive';
 
   if (!divider) {
     to.push(element);
@@ -24,18 +22,17 @@ export const moveToList = (from, to, element, divider = false, toActive = true )
     const selector = toActive ? '.ckeditor5-toolbar-active__buttons' : '.ckeditor5-toolbar-available__buttons';
     setTimeout(() => {
       document.querySelector(`${selector} li:last-child`).focus();
-      if (announcements && announcements[announceFunction]) {
-        announcements[announceFunction](element.label);
-      }
     });
   } else {
     // If this is a divider, then this is being called to remove it from the
     // active buttons list. Focus the item to the left of the removed divider.
     setTimeout(() => {
       document.querySelector(`.ckeditor5-toolbar-active__buttons li:nth-child(${Math.max(elementIndex, 0)})`).focus();
-      if (announcements && announcements[announceFunction]) {
-        announcements[announceFunction](element.label);
-      }
+    });
+  }
+  if (announceChange) {
+    setTimeout(() => {
+      announceChange(element.label);
     });
   }
   from.splice(from.indexOf(element), 1);

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,11 +7,16 @@ export const copyToActiveButtons = (from, to, element) => {
     // A divider added to active buttons will be the last item in the list.
     // Focus that item.
     document.querySelector('.ckeditor5-toolbar-active__buttons li:last-child').focus();
+    if (announcements && announcements.onButtonCopiedActive) {
+      announcements.onButtonCopiedActive(element.label);
+    }
   });
 }
 
 export const moveToList = (from, to, element, divider = false, toActive = true ) => {
   const elementIndex = from.indexOf(element);
+  const announceFunction = toActive ? 'onButtonMovedActive' : 'onButtonMovedInactive';
+
   if (!divider) {
     to.push(element);
     // The selector for the list being moved to is determined by seeing if the
@@ -19,12 +24,18 @@ export const moveToList = (from, to, element, divider = false, toActive = true )
     const selector = toActive ? '.ckeditor5-toolbar-active__buttons' : '.ckeditor5-toolbar-available__buttons';
     setTimeout(() => {
       document.querySelector(`${selector} li:last-child`).focus();
+      if (announcements && announcements[announceFunction]) {
+        announcements[announceFunction](element.label);
+      }
     });
   } else {
     // If this is a divider, then this is being called to remove it from the
     // active buttons list. Focus the item to the left of the removed divider.
     setTimeout(() => {
       document.querySelector(`.ckeditor5-toolbar-active__buttons li:nth-child(${Math.max(elementIndex, 0)})`).focus();
+      if (announcements && announcements[announceFunction]) {
+        announcements[announceFunction](element.label);
+      }
     });
   }
   from.splice(from.indexOf(element), 1);


### PR DESCRIPTION
Two types of changes:

- The calls to announce functions on focus have been refactored. This information is now in a div that is referenced by the button's `aria-describedby`. By doing this, the information regarding the arrow keys happens after the (helpful) default screenreader content, instead of interrupting it. 
- Addressed the problem of buttons being moved not being conveyed to screenreaders. This _does_ happen via an announce, but this interruption is preferable to not having the movement of buttons reported. In a future issue, we can look into possibly delaying this announce so that it doesn't interrupt the default screenreader output.